### PR TITLE
Allow user to ignore errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,8 @@ async function checkForErrors(api: types.IExtensionApi) {
                 + 'Error(s) reported:'
                 + '\n') + errors.map(renderError).join('\n'),
             }, [{ label: 'Ignore', action: () => {
+              //Ignoring will set the launch time to now and dismiss the active notifications.
+              api.dismissNotification('script-extender-errors');
               launchTime = Math.round(Date.now() / 1000);
             } },{ label: 'Close' }]),
         },
@@ -245,6 +247,8 @@ function main(context: types.IExtensionContext) {
     //let launchTime = 0;
 
     context.api.events.on('gamemode-activated', async () => {
+      //Clear any outstanding notifications (they'll come back if we switch back to this game)
+      context.api.dismissNotification('script-extender-errors');
       const hasErrors = await checkForErrors(context.api);
       context.api.store.dispatch(
         actions.setAttributeVisible('mods', 'script-extender-error-check', hasErrors));

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ function getModId(manifest: any, modLookup: { [modPath: string]: string }, dllNa
   return undefined;
 }
 
-async function checkForErrors(api: types.IExtensionApi, launchTime: number) {
+async function checkForErrors(api: types.IExtensionApi) {
   const state: types.IState = api.store.getState();
   const gameDiscovery = selectors.currentGameDiscovery(state);
   if ((gameDiscovery === undefined) || (gameDiscovery.path === undefined)) {
@@ -145,7 +145,9 @@ async function checkForErrors(api: types.IExtensionApi, launchTime: number) {
                 + 'plugin or disable the mod until it is updated.\n\n'
                 + 'Error(s) reported:'
                 + '\n') + errors.map(renderError).join('\n'),
-            }, [{ label: 'Close' }]),
+            }, [{ label: 'Ignore', action: () => {
+              launchTime = Math.round(Date.now() / 1000);
+            } },{ label: 'Close' }]),
         },
         {
           title: 'Dismiss', action: dismiss => {
@@ -209,6 +211,8 @@ function parseSELog(input: string) {
   return errorArray;
 }
 
+let launchTime = 0;
+
 function main(context: types.IExtensionContext) {
   context.requireVersion('>=1.0.4');
 
@@ -238,10 +242,10 @@ function main(context: types.IExtensionContext) {
   context.once(() => {
     context.api.setStylesheet('script-extender-error-check', path.join(__dirname, 'style.scss'));
 
-    let launchTime = 0;
+    //let launchTime = 0;
 
     context.api.events.on('gamemode-activated', async () => {
-      const hasErrors = await checkForErrors(context.api, launchTime);
+      const hasErrors = await checkForErrors(context.api);
       context.api.store.dispatch(
         actions.setAttributeVisible('mods', 'script-extender-error-check', hasErrors));
     });
@@ -251,7 +255,7 @@ function main(context: types.IExtensionContext) {
         launchTime = Math.round(Date.now() / 1000);
       }
       if ((Object.keys(previous).length > 0) && (Object.keys(current).length === 0)) {
-        const hasErrors = await checkForErrors(context.api, launchTime);
+        const hasErrors = await checkForErrors(context.api);
         context.api.store.dispatch(
           actions.setAttributeVisible('mods', 'script-extender-error-check', hasErrors));
       }


### PR DESCRIPTION
Added a new button to ignore error and update the timestamp we use for comparing the log. 

When changing game mode, any pending warnings about script extenders are dismissed to prevent them appearing on the wrong game. 